### PR TITLE
Allow keyword arguments to be passed to sdss_install

### DIFF
--- a/python/sdss_install/application/Argument.py
+++ b/python/sdss_install/application/Argument.py
@@ -78,4 +78,4 @@ def sdss_install():
         help='Name of product to install, starts with [repo, data, deprecated] or assumed to start with repo.')
     parser.add_argument('product_version',nargs='?',default='NO VERSION',
         help='Version of product to install (trunk or specified tag or branch).')
-    return parser.parse_args()
+    return parser

--- a/python/sdss_install/application/Argument.py
+++ b/python/sdss_install/application/Argument.py
@@ -12,7 +12,7 @@ class Argument:
         self.options = self.get_options() if self.get_options else None
         self.options._name = name if self.options else None
 
-def sdss_install():
+def sdss_install(**kwargs):
     '''Add command line arguments for bin file sdss_install'''
     xct = basename(argv[0])
     parser = ArgumentParser(description=__doc__,prog=xct)
@@ -75,4 +75,4 @@ def sdss_install():
         help='Name of product to install, starts with [repo, data, deprecated] or assumed to start with repo.')
     parser.add_argument('product_version',nargs='?',default='NO VERSION',
         help='Version of product to install (trunk or specified tag or branch).')
-    return parser.parse_args()
+    return parser.parse_args(**kwargs)

--- a/python/sdss_install/application/Argument.py
+++ b/python/sdss_install/application/Argument.py
@@ -7,12 +7,15 @@ from argparse import ArgumentParser
 
 class Argument:
     
-    def __init__(self, name=None):
-        self.get_options = globals()[name] if name in globals().keys() else None
+  def __init__(self, name=None, args=None):
+        if name in globals().keys():
+            self.get_options = globals()[name].parse_args(args=args)
+        else:
+            self.get_options = None
         self.options = self.get_options() if self.get_options else None
         self.options._name = name if self.options else None
-
-def sdss_install(**kwargs):
+       
+def sdss_install():
     '''Add command line arguments for bin file sdss_install'''
     xct = basename(argv[0])
     parser = ArgumentParser(description=__doc__,prog=xct)
@@ -75,4 +78,4 @@ def sdss_install(**kwargs):
         help='Name of product to install, starts with [repo, data, deprecated] or assumed to start with repo.')
     parser.add_argument('product_version',nargs='?',default='NO VERSION',
         help='Version of product to install (trunk or specified tag or branch).')
-    return parser.parse_args(**kwargs)
+    return parser.parse_args()

--- a/python/sdss_install/application/Argument.py
+++ b/python/sdss_install/application/Argument.py
@@ -6,15 +6,18 @@ from os.path import basename
 from argparse import ArgumentParser
 
 class Argument:
-    
-  def __init__(self, name=None, args=None):
+
+    def __init__(self, name=None, args=None):
         if name in globals().keys():
-            self.get_options = globals()[name].parse_args(args=args)
+            self.get_options = globals()[name]
+            self.options = self.get_options().parse_args(args=args)
         else:
             self.get_options = None
-        self.options = self.get_options() if self.get_options else None
+            self.options = None
+
         self.options._name = name if self.options else None
        
+    
 def sdss_install():
     '''Add command line arguments for bin file sdss_install'''
     xct = basename(argv[0])


### PR DESCRIPTION
I want to use the `Install` and `Argument` classes of `sdss_install` in a command line utility. I would like to use the same argument parser (`Argument`) so that everything is consistent, instead of duplicating my own. If I run `Argument('sdss_install').options` within an existing command line utility then everything breaks because it is trying to `parse_args()` from `sys.argv`.

This lets me give explicit arguments if needed.