### PR TITLE
Addressed GitHub Issue #26

### DIFF
--- a/bin/sdss_install
+++ b/bin/sdss_install
@@ -52,5 +52,8 @@ else:
         install.build_package()
         if not options.keep: install.clean()
 
+    if options.bootstrap:
+        install.checkout()
+
     install.finalize()
 

--- a/bin/sdss_install_bootstrap
+++ b/bin/sdss_install_bootstrap
@@ -54,8 +54,8 @@ if [[ -z "${MODULESHOME}" ]]; then
     exit 1
 fi
 
-if [[ -n "${verbose}" ]]; then echo "sdss_install_bootstrap - DEBUG - export SDSS_INSTALL_DIR=$(pwd)/github/sdss_install/master"; fi
-export SDSS_INSTALL_DIR=$(pwd)/github/sdss_install/master
+if [[ -n "${verbose}" ]]; then echo "sdss_install_bootstrap - DEBUG - export SDSS_INSTALL_DIR=${SDSS_INSTALL_PRODUCT_ROOT}/github/sdss_install/master"; fi
+export SDSS_INSTALL_DIR=${SDSS_INSTALL_PRODUCT_ROOT}/github/sdss_install/master
 
 if [[ -n "${verbose}" ]]; then echo "sdss_install_bootstrap - DEBUG - export PATH=${SDSS_INSTALL_DIR}/bin:${PATH}"; fi
 export PATH=${SDSS_INSTALL_DIR}/bin:${PATH}
@@ -71,5 +71,3 @@ fi
 if [[ -n "${verbose}" ]]; then echo "sdss_install_bootstrap - INFO - {SDSS_INSTALL_DIR}/bin/sdss_install --github --bootstrap --module-only ${root} ${test} ${verbose}" ; fi
 ${SDSS_INSTALL_DIR}/bin/sdss_install --github --bootstrap --module-only ${root} ${test} ${verbose}
 
-if [[ -n "${verbose}" ]]; then echo "sdss_install_bootstrap - DEBUG - /bin/rm -rf sdss_install/master/.git/"; fi
-/bin/rm -rf sdss_install/master/.git/

--- a/python/sdss_install/install/Install.py
+++ b/python/sdss_install/install/Install.py
@@ -287,6 +287,12 @@ class Install:
             else:                   self.install4.fetch()
             self.import_data()
 
+    def checkout(self):
+        '''Call Install5.checkout'''
+        if self.ready:
+            self.install5.checkout()
+            self.import_data()
+
     def set_github_remote_url(self):
         '''Set the set_github_remote_url() of class Install5'''
         if self.ready and self.options.github:


### PR DESCRIPTION
`sdss_install_bootstrap` previously ran `sdss_install --github --bootstrap --module-only`, in particular `--module-only`  so `Install5.checkout()` was never ran to change from the master branch to the latest tag. This bug fix closes #26.