### PR TITLE
Bootstrap tag version bug

### DIFF
--- a/python/sdss_install/install5/Install5.py
+++ b/python/sdss_install/install5/Install5.py
@@ -83,9 +83,7 @@ class Install5:
     def validate_product_and_version(self):
         '''Validate the product and product version.'''
         if self.ready:
-            self.logger.info('Validating product')
             if self.get_valid_product():
-                self.logger.info('Validating version')
                 if not self.get_valid_version():
                     self.ready = False
                     self.logger.error('Invalid version: {}'.format(version))
@@ -97,6 +95,7 @@ class Install5:
     def get_valid_product(self):
         '''Validate the product'''
         if self.ready:
+            self.logger.info('Validating product')
             # check for master branch
             valid_product = self.is_type(type='repository')
             return valid_product
@@ -105,6 +104,7 @@ class Install5:
         '''Validate the product version'''
         valid_version = None
         if self.ready:
+            self.logger.info('Validating version')
             version = self.options.product_version
             is_master = (version == 'master')
             is_branch = True if is_master else self.is_type(type='branch')

--- a/python/sdss_install/install5/Install5.py
+++ b/python/sdss_install/install5/Install5.py
@@ -84,21 +84,19 @@ class Install5:
         '''Validate the product and product version.'''
         if self.ready:
             if self.get_valid_product():
-                if not self.get_valid_version():
-                    self.ready = False
-                    self.logger.error('Invalid version: {}'.format(version))
-            else:
-                self.ready = False
-                self.logger.error('Invalid product. {} '
-                                    .format(self.options.product) )
+                self.get_valid_version()
 
     def get_valid_product(self):
         '''Validate the product'''
+        valid_product = None
         if self.ready:
             self.logger.info('Validating product')
             # check for master branch
             valid_product = self.is_type(type='repository')
-            return valid_product
+            if not valid_product:
+                self.ready = False
+                self.logger.error('Invalid product. {} '.format(self.options.product) )
+        return valid_product
 
     def get_valid_version(self):
         '''Validate the product version'''
@@ -110,6 +108,9 @@ class Install5:
             is_branch = True if is_master else self.is_type(type='branch')
             is_tag    = False if is_branch else self.is_type(type='tag')
             valid_version =  bool(is_master or is_branch or is_tag)
+            if not valid_version:
+                self.ready = False
+                self.logger.error('Invalid version: {}'.format(version))
         return valid_version
 
     def get_bootstrap_version(self):


### PR DESCRIPTION
The command `git describe --tags` can have varying output. Replacement of a Python split command with a Regex match command fixed a tag version bug in Install5.get_bootstrap_version(). The current sdss_install tag naming convention `d.d.d` must be maintained for the regex command to work properly.

Also, `Install5.set_ready()` was refactored to use `get_valid_version()` after `get_bootstrap_version()` in `set_ready()`.

