### PR TITLE
Fixed Python3 incompatability in Install5.get_matches

### DIFF
--- a/python/sdss_install/install5/Install5.py
+++ b/python/sdss_install/install5/Install5.py
@@ -173,7 +173,7 @@ class Install5:
         matches = None
         if self.ready:
             if regex and string:
-                string = str(string.decode("utf-8"))
+                string = string.decode("utf-8") if isinstance(string,bytes) else string
                 pattern = compile(regex)
                 iterator = pattern.finditer(string)
                 matches = list()

--- a/python/sdss_install/install5/Install5.py
+++ b/python/sdss_install/install5/Install5.py
@@ -173,6 +173,7 @@ class Install5:
         matches = None
         if self.ready:
             if regex and string:
+                string = str(string)
                 pattern = compile(regex)
                 iterator = pattern.finditer(string)
                 matches = list()

--- a/python/sdss_install/install5/Install5.py
+++ b/python/sdss_install/install5/Install5.py
@@ -173,7 +173,7 @@ class Install5:
         matches = None
         if self.ready:
             if regex and string:
-                string = str(string)
+                string = str(string.decode("utf-8"))
                 pattern = compile(regex)
                 iterator = pattern.finditer(string)
                 matches = list()


### PR DESCRIPTION
The commands
```
                pattern = compile(regex)
                iterator = pattern.finditer(string)
```
don't run using Python3 when string not a string object, so I added `string = str(string.decode("utf-8"))`.