### PR TITLE
Testing Module class

### DIFF
--- a/bin/module_test.py
+++ b/bin/module_test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# $Id: sdss4install 70491 2016-06-15 19:16:07Z joelbrownstein $
+#
+from sdss_install import __version__
+from sdss_install.application import Argument
+from sdss_install.install import Install
+from sdss_install.install.modules import Modules
+from sdss_install.utils.module import Module
+
+
+options = Argument('sdss_install').options
+install = Install(options=options)
+logger = install.logger
+module = Module(logger=logger,options=options)
+ready = bool(options and install and logger and module)
+
+if not ready:
+    print('An error occurred. ready: {}' % ready)
+else:
+    command = 'unload'
+    arguments = 'sdss_github'
+    module.set_command(command=command,arguments=arguments)
+    module.execute_command()
+
+    print('module.stdout: %r'% module.stdout)
+    print('module.stderr: %r'% module.stderr)
+    print('module.returncode: %r'% module.returncode)
+    print('command: %r'% command)
+    print('arguments: %r'% arguments)
+
+    command = 'load'
+    arguments = 'sdss_github'
+    module.set_command(command=command,arguments=arguments)
+    module.execute_command()
+
+    print('module.stdout: %r'% module.stdout)
+    print('module.stderr: %r'% module.stderr)
+    print('module.returncode: %r'% module.returncode)
+    print('command: %r'% command)
+    print('arguments: %r'% arguments)

--- a/python/sdss_install/utils/module.py
+++ b/python/sdss_install/utils/module.py
@@ -40,9 +40,9 @@ class Module:
         if self.ready:
             self.options = options if options else None
             if not self.options:
-                self.ready = False
-                self.logger.error('Unable to set_options' +
-                                  'self.options: {}'.format(self.options))
+                #self.ready = False # Don't require in the case of testing
+                self.logger.warning('Unable to set_options' +
+                                    'self.options: {}'.format(self.options))
 
     def set_modules(self):
         self.set_modules_home()
@@ -55,7 +55,7 @@ class Module:
         self.modules_home = dict()
         if self.ready:
             modules_home = None
-            if self.options.modules_home:
+            if self.options and self.options.modules_home:
                 modules_home = self.options.modules_home
             else:
                 try: modules_home = environ['MODULESHOME']

--- a/python/sdss_install/utils/module.py
+++ b/python/sdss_install/utils/module.py
@@ -120,7 +120,10 @@ class Module:
         if self.command:
             proc = Popen(self.command, stdout=PIPE, stderr=PIPE)
             if proc:
-                (self.stdout, self.stderr) = proc.communicate() if proc else (None,None)
+                (out, err) = proc.communicate() if proc else (None,None)
+                self.stdout = out.decode("utf-8") if isinstance(out,bytes) else out
+                self.stderr = err.decode("utf-8") if isinstance(err,bytes) else err
+
                 self.returncode = proc.returncode if proc else None
             else:
                 self.ready = False


### PR DESCRIPTION
Currently the `sdss_install.utils.module Module` class is used to load modules that the sdss_install'd software product depends upon, using
```
for (product,version) in self.dependencies:
    self.load(product=product,version=version)
```
where the `load` method executes code including the following
```
Module.set_command('load',arguments=join(product,version))
Module.execute_command()
``` 
However, it seems that the `Module` class doesn't actually load the modules, as is shown by running the `bin/module_test.py` script and subsequently running `module list` in bash.