### PR TITLE
Added --https command line option 

### DIFF
--- a/python/sdss_install/application/Argument.py
+++ b/python/sdss_install/application/Argument.py
@@ -84,4 +84,6 @@ def sdss_install():
     parser.add_argument('-x', '--external_dependencies', action='store', dest='external_dependencies',
         metavar='DIR', help='Set a string of external dependency clone commands',
         default=str())
+    parser.add_argument('-H', '--https', action='store_true', dest='https',
+        help='Use GitHub https instead of ssh', default=False)
     return parser

--- a/python/sdss_install/install5/Install5.py
+++ b/python/sdss_install/install5/Install5.py
@@ -232,7 +232,9 @@ class Install5:
             if type:
                 product = product if product else self.options.product
                 version = version if version else self.options.product_version
-                github_url = github_url if github_url else 'git@github.com:sdss'
+                github_url = (github_url if github_url
+                             else 'https://github.com/sdss' if self.options.https
+                             else 'git@github.com:sdss')
                 url = join(github_url,product + '.git')
                 options = {'repository' : '--heads', # for validating product
                            'branch'     : '--heads', # for validating product_version
@@ -276,10 +278,14 @@ class Install5:
 
     def set_sdss_github_remote_url(self):
         '''Set the SDSS GitHub HTTPS remote URL'''
+        self.github_remote_url = None
         if self.ready:
             product = self.options.product if self.options else None
-            self.github_remote_url = ('git@github.com:sdss/%s.git' % product
-                                      if product else None)
+            if product:
+                self.github_remote_url = ('https://github.com/sdss/{!s}.git'.format(product)
+                                          if self.options.https else
+                                          'git@github.com:sdss/{!s}.git'.format(product)
+                                          )
 
     def fetch(self):
         '''


### PR DESCRIPTION
The new command line option `--https` enables the user to use `sdss_install` with either `https` or `ssh`. If the `--https` option is used for private repositories, then the username and password are required (possibly multiple times). Closes #46. 